### PR TITLE
Make batchify act more like the pytorch DataLoader

### DIFF
--- a/padl/transforms.py
+++ b/padl/transforms.py
@@ -1730,7 +1730,7 @@ class Batchify(ClassTransform):
         if Transform.pd_stage != 'infer':
             return args
         if isinstance(args, (tuple, list)):
-            return tuple([self(x) for x in args])
+            return torch.tensor([self(x) for x in args])
         if isinstance(args, torch.Tensor):
             return args.unsqueeze(self.dim)
         if isinstance(args, (float, int)):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
I propose to modify `Batchify` to act more like the pytorch data loader in that it will return a `torch.tensor` of `torch.tensor`'s instead of a `tuple` of `torch.tensor`'s. This would only affect `Batchify` when calling with the `infer` stage. It does not break any of the current tests and should work the same (more or less) as returning a `tuple`. 

Most importantly, I think this makes the behavior more consistent between `infer` and `eval`/`train` where after the `Batchify` step you can be certain you will always be working with a `torch.tensor`.

What do you think @wuhu @blythed @jasonkhadka @eramdiaz ?
