### PR TITLE
Have _move_to_device return the same type as was given

### DIFF
--- a/padl/transforms.py
+++ b/padl/transforms.py
@@ -62,8 +62,10 @@ def _move_to_device(args, device):
     :param args: args to move to device
     :param device: device to move to
     """
-    if isinstance(args, (tuple, list)):
+    if isinstance(args, tuple):
         return tuple([_move_to_device(x, device) for x in args])
+    if isinstance(args, list):
+        return list([_move_to_device(x, device) for x in args])
     if isinstance(args, torch.Tensor):
         return args.to(device)
     return args


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
I think `_move_to_device` should only move torch tensors to device and not modify the structure of the args. So if a `tuple` of `tensors` is given it returns a `tuple` of `tensors` and the same for `lists` of `tensors`. Right now it will convert a `list` of `tensors` to a `tuple` of `tensors` which could be potentially confusing. 
