### PR TITLE
Fixed typo in requirements for docs

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,3 @@
 sphinx
-sphinx-rtd-themse
+sphinx-rtd-theme
 m2r


### PR DESCRIPTION
Fixed typo in requirements for docs