### PR TITLE
345 python37

### DIFF
--- a/padl/dumptools/inspector.py
+++ b/padl/dumptools/inspector.py
@@ -322,7 +322,7 @@ def get_segment_from_frame(caller_frame: types.FrameType, segment_type, return_l
 
     lineno = caller_frame.f_lineno
     # in python <= 3.7, the lineno points to the end of
-    # the statement rathere than the beginning, therefore we need to decrement it
+    # the statement rather than the beginning, therefore we need to decrement it
     if segment_type == 'call':
         lines = original(full_source).split('\n')
         while '(' not in lines[lineno - 1]:

--- a/padl/dumptools/inspector.py
+++ b/padl/dumptools/inspector.py
@@ -320,7 +320,15 @@ def get_segment_from_frame(caller_frame: types.FrameType, segment_type, return_l
     except KeyError:
         full_source = get_source(caller_frame.f_code.co_filename)
 
-    source, offset = get_statement(original(full_source), caller_frame.f_lineno)
+    lineno = caller_frame.f_lineno
+    # in python <= 3.7, the lineno points to the end of
+    # the statement rathere than the beginning, therefore we need to decrement it
+    if segment_type == 'call':
+        lines = original(full_source).split('\n')
+        while '(' not in lines[lineno - 1]:
+            lineno -= 1
+
+    source, offset = get_statement(original(full_source), lineno)
     # the source can contain surrounding stuff we need to discard
     # as we only have the line number (this is what makes this complicated)
 

--- a/padl/dumptools/inspector.py
+++ b/padl/dumptools/inspector.py
@@ -185,16 +185,36 @@ def get_statement(source: str, lineno: int):
 
 
 def _get_statement_from_block(block: str, lineno_in_block: int):
-    """Get a statement from a block."""
+    """Get statements at like *lineno_in_block* from a code block.
+
+    Example:
+
+    >>> block = \
+    ...: '''bla = 1
+    ...: hehe = 2
+    ...: x = X(1,
+    ...:       2,
+    ...:       3)
+    ...: '''
+    >>> _get_statement_from_block(block, 4)
+    'x = X(1,\n      2,\n      3)', 1)
+
+    :param block: The code block to get the statements from.
+    :param lineno_in_block: Line number which the statement must include. Counted from 1.
+    :returns: A tuple of string with the found statements and and offset between the beginning of
+        the match and *lineno_in_block*.
+    """
     module = ast.parse(block)
     stmts = []
-    offset = 0
+    offset = None
     for stmt in module.body:
         position = ast_utils.get_position(block, stmt)
         if position.lineno <= lineno_in_block <= position.end_lineno:
             stmts.append(ast_utils.get_source_segment(block, stmt))
-            offset = lineno_in_block - position.lineno
-    assert len(stmts) == 1
+            if offset is None:
+                offset = lineno_in_block - position.lineno
+    if offset is None:
+        offset = 0
     return '\n'.join(stmts), offset
 
 

--- a/padl/wrap.py
+++ b/padl/wrap.py
@@ -38,16 +38,19 @@ def _wrap_function(fun, ignore_scope=False, call_info: inspector.CallInfo = None
     """
     caller = inspect.stack()[2]
 
-    try:
-        # case transform(f)
-        call = inspector.get_segment_from_frame(caller.frame, 'call')
-    except RuntimeError:
+    if '@' in caller.code_context[0]:
+        call = None
+    else:
         try:
-            # case importer.np.transform
-            call = inspector.get_segment_from_frame(caller.frame, 'attribute')
+            # case transform(f)
+            call = inspector.get_segment_from_frame(caller.frame, 'call')
         except RuntimeError:
-            # decorator case @transform ..
-            call = None
+            # case importer.np.transform
+            try:
+                call = inspector.get_segment_from_frame(caller.frame, 'attribute')
+            except RuntimeError:
+                # needed for python 3.7 support
+                call = None
 
     # if this is the decorator case we drop one leven from the scope (this is the decorated
     # function itself)

--- a/tests/unittests/test_dump.py
+++ b/tests/unittests/test_dump.py
@@ -240,6 +240,14 @@ def test_dumping_selfassign():
     assert SelfAssign(1)._pd_dumps() == read_dump('selfassign')
 
 
+def test_multiline_init():
+    a = MyClassTransform(
+        a=1,
+        b=2,
+        c=3
+    )  # no further testing, this should just not fail
+
+
 class TestOtherModule:
     def test_import_function(self):
         importdump(tim)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Fixes #345 

Initializing transform objects in multiple lines like

```python
x = Transform(
   a=1,
   b=2,
   c=3
)
```
failed as the semantics `f_lineno` code extraction depends on has changed between 3.7 and 3.8 (https://bugs.python.org/issue38283).

This PR deals with that.