### PR TITLE
Use pd_to in the pd_pre, pd_for, and pd_post properties

### DIFF
--- a/padl/transforms.py
+++ b/padl/transforms.py
@@ -850,7 +850,7 @@ class Transform:
     def pd_preprocess(self) -> "Transform":
         """The preprocessing part of the transform. The device must be propagated from self."""
         pre = self.pd_stages[0]
-        pre.pd_device = self.pd_device
+        pre.pd_to(self.pd_device)
         return pre
 
     @property
@@ -858,14 +858,14 @@ class Transform:
         """The forward part of the transform (that what's typically done on the GPU).
         The device must be propagated from self."""
         forward = self.pd_stages[1]
-        forward.pd_device = self.pd_device
+        forward.pd_to(self.pd_device)
         return forward
 
     @property
     def pd_postprocess(self) -> "Transform":
         """The postprocessing part of the transform. The device must be propagated from self."""
         post = self.pd_stages[2]
-        post.pd_device = self.pd_device
+        post.pd_to(self.pd_device)
         return post
 
     def pd_to(self, device: str) -> "Transform":

--- a/tests/unittests/test_transforms.py
+++ b/tests/unittests/test_transforms.py
@@ -776,8 +776,7 @@ class TestTransformDeviceCheck:
         self.transform_1.pd_to('gpu')
         self.transform_1.transforms[1].pd_to('cpu')
 
-        with pytest.raises(WrongDeviceError):
-            self.transform_1.pd_forward_device_check()
+        assert self.transform_1.pd_forward_device_check()
 
         self.transform_2.pd_to('gpu')
         assert self.transform_2.pd_forward_device_check()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
This is reverting a change made in PR #341 . `pd_to` needs to be used when creating `pd_preprocess`, `pd_forward`, and `pd_postprocess` otherwise the children transforms will not correctly inherit the correct device. 
