### PR TITLE
452 pydev warning

### DIFF
--- a/padl/dumptools/inspector.py
+++ b/padl/dumptools/inspector.py
@@ -10,6 +10,10 @@ try:
 except ImportError:
     from typing_extensions import Literal
 from typing import Callable, Optional
+try:
+    from pydevd_tracing import SetTrace
+except ImportError:
+    SetTrace = sys.settrace
 
 from padl.dumptools import ast_utils, symfinder, var2mod
 from padl.dumptools.sourceget import get_source, original, cut
@@ -144,7 +148,7 @@ def trace_this(tracefunc: Callable, frame: Optional[types.FrameType] = None, *ar
 
     if previous_tracefunc is None:
         # set global tracefunc to something, this is required to enable local tracing
-        sys.settrace(lambda _a, _b, _c: None)
+        SetTrace(lambda _a, _b, _c: None)
 
     frame.f_trace = trace
 

--- a/padl/dumptools/inspector.py
+++ b/padl/dumptools/inspector.py
@@ -142,7 +142,7 @@ def trace_this(tracefunc: Callable, frame: Optional[types.FrameType] = None, *ar
     def trace(frame, event, arg):
         tracefunc(frame, event, arg, *args, **kwargs)
         if event == 'return':
-            sys.settrace(previous_tracefunc)
+            SetTrace(previous_tracefunc)
         if previous_tracefunc is not None:
             previous_tracefunc(frame, event, arg)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ torch
 numpy
 astunparse
 asttokens; python_version < '3.8'
-importlib_metadata
+importlib_metadata>=4.8.2


### PR DESCRIPTION
## Description

Pydev doesn't like other packages to use sys.settrace and warns about it due to the danger that it may interfere with the pydev debugger. This is explained here: https://pydev.blogspot.com/2007/06/why-cant-pydev-debugger-work-with.html.
I've checked if debugging is affected - it is not - and replaced sys.settrace by pydevd_trace.SetTrace if available as suggested in one of the above page's comments. This supresses the warning.

Fixes #452
